### PR TITLE
Move templatetags from webpage into base_project

### DIFF
--- a/base_project/templatetags/browsing_extras.py
+++ b/base_project/templatetags/browsing_extras.py
@@ -1,0 +1,52 @@
+from django import template
+from django.contrib.contenttypes.models import ContentType
+register = template.Library()
+
+
+@register.simple_tag
+def nav_menu(app=None):
+
+    """creates links to all class of the passed in application
+    for which get_listview_url() methods have been registered"""
+
+    if app:
+        models = ContentType.objects.filter(app_label=app)
+        result = []
+        for x in models:
+            modelname = x.name
+            modelname = modelname.replace(" ", "").lower()
+            try:
+                fetched_model = ContentType.objects.get(
+                    app_label=app, model=modelname).model_class()
+                item = {
+                    'name': modelname.title(),
+                }
+            except Exception as e:
+                item = {
+                    'name': None
+                }
+            try:
+                item['link'] = fetched_model.get_listview_url()
+                result.append(item)
+            except AttributeError:
+                item['link'] = None
+        return result
+
+
+@register.inclusion_tag('webpage/tags/class_definition.html', takes_context=True)
+def class_definition(context):
+    values = {}
+    try:
+        values['class_name'] = context['class_name']
+        values['docstring'] = context['docstring']
+    except Exception as e:
+        pass
+    return values
+
+
+@register.inclusion_tag('webpage/tags/column_selector.html', takes_context=True)
+def column_selector(context):
+    try:
+        return {'columns': context['togglable_colums']}
+    except Exception as e:
+        return {'columns': None}

--- a/base_project/templatetags/webpage_extras.py
+++ b/base_project/templatetags/webpage_extras.py
@@ -1,0 +1,52 @@
+from django import template
+from webpage.utils import PROJECT_METADATA as PM
+
+register = template.Library()
+
+
+@register.simple_tag
+def projects_metadata(key):
+    return PM[key]
+
+
+@register.simple_tag
+def get_verbose_name(instance, field_name):
+    """
+    Returns verbose_name for a field.
+    inspired by https://stackoverflow.com/questions/14496978/fields-verbose-name-in-templates
+    call in template like e.g. 'get_verbose_name <classname> "<fieldname>" '
+    """
+    try:
+        label = instance._meta.get_field(field_name).verbose_name
+    except Exception as e:
+        label = None
+    if label:
+        return "{}".format(label)
+    else:
+        return "No verbose name for '{}' provided".format(field_name)
+
+
+@register.simple_tag
+def get_help_text(instance, field_name):
+    """
+    Returns help_text for a field.
+    inspired by https://stackoverflow.com/questions/14496978/fields-verbose-name-in-templates
+    call in template like e.g.  get_help_text <classname> "<fieldname>"
+    """
+    try:
+        label = instance._meta.get_field(field_name).help_text
+    except Exception as e:
+        label = None
+    if label:
+        return "{}".format(label)
+    else:
+        return "No helptext for '{}' provided".format(field_name)
+
+
+@register.inclusion_tag('webpage/tags/social_media.html', takes_context=True)
+def social_media(context):
+    """ looks for a 'social_media' key in webpage.py and renders html-tags for each entry """
+    values = {}
+    values['sm_items'] = PM['social_media']
+    values['sm_len'] = len(PM['social_media'])
+    return values


### PR DESCRIPTION
**Describe your changes**
Moves existing `templatetags` files from webpage directory into `base_project` app for reuse in individual Ontologies apps.

**Additional context**
Template tags are not picked up on from `webpage`, but can be used to modify front-end output when placed into individual app directories (as-is, without needing to adapt any settings files).

**Related issues and PRs**
See PR acdh-oeaw/apis-rdf-devops#5, which deletes these files from the `webpage` directory. 

**Checklist (Replace the space in square brackets with a lowercase x for all that apply)**
- [x] My changes don't generate new warnings or errors
- [ ] My changes follow the project's code formatting rules and style guidelines
- [ ] I have commented my code with Docstrings and code comments, particularly complex, unusual or hard-to-read code
- [ ] I have updated the project documentation to reflect the changes I introduce
- [ ] I have added new unit tests or updated existing ones to demonstrate my changes works
