### PR TITLE
Fix: drop hardcoded SECRET_KEY

### DIFF
--- a/base_project/settings/local_settings_template.py
+++ b/base_project/settings/local_settings_template.py
@@ -7,11 +7,6 @@
 
 from .server_settings import *
 
-# SECRET_KEY must not be empty or Django won't run.
-# Use a unique, unpredictable value,
-# see: https://docs.djangoproject.com/en/4.0/ref/settings/#secret-key
-SECRET_KEY = ""
-
 # DEBUG, DEV_VERSION are optional variables which override defaults
 # for production environments set in server_settings.py
 # Comment them out if/when they are not needed.

--- a/jelinek/settings/server_settings.py
+++ b/jelinek/settings/server_settings.py
@@ -4,9 +4,6 @@ import dj_database_url
 import os
 
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "^mm-24*i-6iecm7c@z9l+7%^ns^4g^z!8=dgffg4ulggr-4=1%"
-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 # REDMINE_ID = "14590"
@@ -46,9 +43,6 @@ REST_FRAMEWORK["DEFAULT_PERMISSION_CLASSES"] = (
 
 # HAYSTACK_DEFAULT_OPERATOR = "OR"
 
-SECRET_KEY = (
-    "d3j@454545()(/)@zlck/6dsaf*#sdfsaf*#sadflj/6dsfk-11$)d6ixcvjsdfsdf&-u35#ayi"
-)
 DEBUG = True
 DEV_VERSION = False
 

--- a/sicprod/settings/server_settings.py
+++ b/sicprod/settings/server_settings.py
@@ -4,9 +4,6 @@ import dj_database_url
 import os
 
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "^mm-24*i-6iecm7c@z9l+7%^ns^4g^z!8=dgffg4ulggr-4=1%"
-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 # REDMINE_ID = "14590"
@@ -46,9 +43,6 @@ REST_FRAMEWORK["DEFAULT_PERMISSION_CLASSES"] = (
 
 # HAYSTACK_DEFAULT_OPERATOR = "OR"
 
-SECRET_KEY = (
-    "d3j@454545()(/)@zlck/6dsaf*#sdfsaf*#sadflj/6dsfk-11$)d6ixcvjsdfsdf&-u35#ayi"
-)
 DEBUG = True
 DEV_VERSION = False
 

--- a/tibschol/settings/server_settings.py
+++ b/tibschol/settings/server_settings.py
@@ -5,9 +5,6 @@ import dj_database_url
 import os
 
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "^mm-24*i-6iecm7c@z9l+7%^ns^4g^z!8=dgffg4ulggr-4=1%"
-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 # REDMINE_ID = "14590"
@@ -45,9 +42,6 @@ REST_FRAMEWORK["DEFAULT_PERMISSION_CLASSES"] = (
 
 # HAYSTACK_DEFAULT_OPERATOR = "OR"
 
-SECRET_KEY = (
-    "d3j@454545()(/)@zlck/6dsaf*#sdfsaf*#sadflj/6dsfk-11$)d6ixcvjsdfsdf&-u35#ayi"
-)
 DEBUG = True
 DEV_VERSION = False
 


### PR DESCRIPTION
The `server_settings` modules all include `apis.settings.base` which uses an environment variable to set the SECRET_KEY since commit 2ad2719 in the apis-devops-rdf repository. Therefore we can drop the SECRET_KEYs define locally.
Closes #14

**Describe your changes**
A clear and concise description of what your pull request achieves. Use bullet points
to list individual changes where sensible, e.g. if your PR combines multiple changes
or spans multiple commits:

- Change A
- Change B

**Additional context**
Add any other context about your changes here, e.g. your motivation, notes on
implementation decisions, references to discussions preceding your PR etc.

**Related issues and PRs**
Link to issues your pull request resolves and other PRs it affects. E.g.

Resolves issue:
- #11
- #42

Supersedes PR:
- #13

**Checklist (Replace the space in square brackets with a lowercase x for all that apply)**
- [ ] My changes don't generate new warnings or errors
- [ ] My changes follow the project's code formatting rules and style guidelines
- [ ] I have commented my code with Docstrings and code comments, particularly complex, unusual or hard-to-read code
- [ ] I have updated the project documentation to reflect the changes I introduce
- [ ] I have added new unit tests or updated existing ones to demonstrate my changes works
