### PR TITLE
sicprod: Remove sentry configuration from settings file

### DIFF
--- a/sicprod/settings/server_settings.py
+++ b/sicprod/settings/server_settings.py
@@ -78,22 +78,3 @@ INSTALLED_APPS += ["apis_bibsonomy"]
 APIS_RELATIONS_FILTER_EXCLUDE += ["annotation", "annotation_set_relation"]
 
 #INSTALLED_APPS.append("apis_highlighter")
-import sentry_sdk
-from sentry_sdk.integrations.django import DjangoIntegration
-
-sentry_sdk.init(
-    dsn="https://3ef6570c9313481bb37eb77ae0dd07c2@o4504360778661888.ingest.sentry.io/4504360934440960",
-    integrations=[
-        DjangoIntegration(),
-    ],
-    environment="production",
-
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    # We recommend adjusting this value in production.
-    traces_sample_rate=1.0,
-
-    # If you wish to associate users to errors (assuming you are using
-    # django.contrib.auth) you may enable sending PII data.
-    send_default_pii=True
-)


### PR DESCRIPTION
The configuration is now part of the base settings file

Closes: #22
