### PR TITLE
Update path to caching module

### DIFF
--- a/sicprod/ontology_specific_scripts/check_and_migrate_tec_tt.py
+++ b/sicprod/ontology_specific_scripts/check_and_migrate_tec_tt.py
@@ -3,7 +3,7 @@ from apis_core.apis_entities.models import *
 from apis_core.apis_relations.models import *
 from apis_core.apis_vocabularies.models import *
 from apis_ontology.models import *
-from apis_core.helper_functions import caching
+from apis_core.utils import caching
 
 
 def run(*args, **kwargs):

--- a/tibschol/ontology_specific_scripts/check_and_migrate_tec_tt.py
+++ b/tibschol/ontology_specific_scripts/check_and_migrate_tec_tt.py
@@ -3,7 +3,7 @@ from apis_core.apis_entities.models import *
 from apis_core.apis_relations.models import *
 from apis_core.apis_vocabularies.models import *
 from apis_ontology.models import *
-from apis_core.helper_functions import caching
+from apis_core.utils import caching
 
 
 def run(*args, **kwargs):


### PR DESCRIPTION
Fix import statements in helper scripts
following package rename in apis-core-rdf acdh-oeaw/apis-core-rdf@0f083d5

**Describe your changes**
Updates import statements used by `check_and_migrate_tec_tt.py` script in various ontologies project folders following breaking change introduced in https://github.com/acdh-oeaw/apis-core-rdf/pull/132

