### PR TITLE
feat: introduce sicprod/start.sh and update filter setting

### DIFF
--- a/sicprod/filters.py
+++ b/sicprod/filters.py
@@ -1,0 +1,7 @@
+from django.db.models import Q
+
+def name_alternative_name_filter(queryset, name, value):
+    return queryset.filter(
+        Q(name__icontains=value) |
+        Q(first_name__icontains=value) |
+        Q(alternative_label__icontains=value))

--- a/sicprod/settings/server_settings.py
+++ b/sicprod/settings/server_settings.py
@@ -77,6 +77,7 @@ INSTALLED_APPS += ["apis_bibsonomy"]
 
 APIS_RELATIONS_FILTER_EXCLUDE += ["annotation", "annotation_set_relation"]
 
+from apis_ontology.filters import name_alternative_name_filter
 #INSTALLED_APPS.append("apis_highlighter")
 APIS_ENTITIES = {
     "Salary": {
@@ -94,15 +95,6 @@ APIS_ENTITIES = {
         "form_order": ["name", "kind", "lat", "lng", "status", "collection"],
         "table_fields": ["name"],
         "additional_cols": ["id", "lat", "lng", "part_of"],
-        "list_filters": [
-            {"name": {"method": "name_label_filter"}},
-            {"collection": {"label": "Collection"}},
-            {"kind": {"label": "Kind of Place"}},
-            "related_entity_name",
-            "related_relationtype_name",
-            "lat",
-            "lng",
-        ],
     },
     "Person": {
         "merge": True,
@@ -125,17 +117,9 @@ APIS_ENTITIES = {
             "status",
         ],
         "additional_cols": ["id", "profession", "gender"],
-        "list_filters": [
-            "name",
-            {"gender": {"label": "Gender"}},
-            {"start_date": {"label": "Date of Birth"}},
-            {"end_date": {"label": "Date of Death"}},
-            {"profession": {"label": "Profession"}},
-            {"title": {"label": "Title"}},
-            {"collection": {"label": "Collection"}},
-            "related_entity_name",
-            "related_relationtype_name",
-        ],
+        "list_filters": {
+            "name": {"method": name_alternative_name_filter, "label": "Name or first name or alternative name"},
+        }
     },
     "Institution": {
         "merge": True,
@@ -152,15 +136,6 @@ APIS_ENTITIES = {
             "id",
             "kind",
         ],
-        "list_filters": [
-            {"name": {"label": "Name or label of institution"}},
-            {"kind": {"label": "Kind of Institution"}},
-            {"start_date": {"label": "Date of foundation"}},
-            {"end_date": {"label": "Date of termination"}},
-            {"collection": {"label": "Collection"}},
-            "related_entity_name",
-            "related_relationtype_name",
-        ],
     },
     "Work": {
         "merge": True,
@@ -169,29 +144,12 @@ APIS_ENTITIES = {
             "id",
             "kind",
         ],
-        "list_filters": [
-            {"name": {"label": "Name of work"}},
-            {"kind": {"label": "Kind of Work"}},
-            {"start_date": {"label": "Date of creation"}},
-            {"collection": {"label": "Collection"}},
-            "related_entity_name",
-            "related_relationtype_name",
-        ],
     },
     "Event": {
         "merge": True,
         "search": ["name", "alternative_label"],
         "additional_cols": [
             "id",
-        ],
-        "list_filters": [
-            {"name": {"label": "Name of event"}},
-            {"kind": {"label": "Kind of Event"}},
-            {"start_date": {"label": "Date of beginning"}},
-            {"end_date": {"label": "Date of end"}},
-            {"collection": {"label": "Collection"}},
-            "related_entity_name",
-            "related_relationtype_name",
         ],
     },
 }

--- a/sicprod/start.sh
+++ b/sicprod/start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+pip install --user git+https://github.com/acdh-oeaw/apis-core-rdf@994524c


### PR DESCRIPTION
The start.sh allows us to install apis-core from the dev branch. The dev
branch contains a fix for the filter settings that changes the
`list_filters` format. For the `Person` we set a custom filter method
for the name field.
