### PR TITLE
fix: sets API to readonly if no authentication is sent

### DIFF
--- a/jelinek/settings/server_settings.py
+++ b/jelinek/settings/server_settings.py
@@ -36,7 +36,7 @@ ALLOWED_CIDR_NETS = ["10.0.0.0/8", "127.0.0.0/8"]
 
 REST_FRAMEWORK["DEFAULT_PERMISSION_CLASSES"] = (
     # "rest_framework.permissions.DjangoModelPermissions",
-    "rest_framework.permissions.IsAuthenticated",
+    "rest_framework.permissions.IsAuthenticatedOrReadOnly",
     # "rest_framework.permissions.DjangoObjectPermissions",
     # use IsAuthenticated for every logged in user to have global edit rights
 )


### PR DESCRIPTION
this is needed to allow the frontend to not send any authentication information